### PR TITLE
Implement XITDBCursor

### DIFF
--- a/src/xitdb/db.clj
+++ b/src/xitdb/db.clj
@@ -85,7 +85,10 @@
   "Performs the 'swap!' operation while locking `db.lock`.
   Returns the new value of the database.
   If the binding `*return-history?*` is true, returns
-  `[current-history-index db-before db-after]`."
+  `[current-history-index db-before db-after]`.
+  If `keypath` is not empty, the result of `f` will be written to the db at `keypath` rather
+  than db root.
+  Similarly, if `keypath` is not empty, the returned value will be the value at `keypath`."
   [xitdb base-keypath f & args]
   (let [^ReentrantLock lock (.-lock xitdb)]
     (when (.isHeldByCurrentThread lock)

--- a/src/xitdb/hash_map.clj
+++ b/src/xitdb/hash_map.clj
@@ -1,6 +1,7 @@
 (ns xitdb.hash-map
   (:require
     [xitdb.common :as common]
+    [xitdb.util.conversion :as conversion]
     [xitdb.util.operations :as operations])
   (:import
     [io.github.radarroark.xitdb
@@ -157,7 +158,7 @@
     (let [cursor (operations/map-read-cursor whm key)]
       (if (nil? cursor)
         not-found
-        (common/-read-from-cursor (operations/map-write-cursor whm key)))))
+        (common/-read-from-cursor (conversion/map-write-cursor whm key)))))
 
   clojure.lang.Seqable
   (seq [this]

--- a/src/xitdb/util/operations.clj
+++ b/src/xitdb/util/operations.clj
@@ -3,7 +3,7 @@
     [xitdb.util.conversion :as conversion]
     [xitdb.util.validation :as validation])
   (:import
-    [io.github.radarroark.xitdb ReadArrayList ReadCountedHashMap ReadCountedHashSet ReadHashMap ReadHashSet ReadLinkedArrayList Tag WriteArrayList WriteCursor WriteHashMap WriteHashSet WriteLinkedArrayList]))
+    [io.github.radarroark.xitdb ReadArrayList ReadCountedHashMap ReadCountedHashSet ReadHashMap ReadHashSet ReadLinkedArrayList Tag WriteArrayList WriteCountedHashMap WriteCountedHashSet WriteCursor WriteHashMap WriteHashSet WriteLinkedArrayList]))
 
 ;; ============================================================================
 ;; Array List Operations
@@ -151,14 +151,6 @@
   [^ReadHashMap rhm key]
   (let [key-hash (conversion/db-key-hash (-> rhm .cursor .db) key)]
     (.getCursor rhm key-hash)))
-
-
-(defn map-write-cursor
-  "Gets a write cursor for the specified key in a WriteHashMap.
-  Creates the key if it doesn't exist."
-  [^WriteHashMap whm key]
-  (let [key-hash (conversion/db-key-hash (-> whm .cursor .db) key)]
-    (.putCursor whm key-hash)))
 
 ;; ============================================================================
 ;; Set Operations  

--- a/src/xitdb/xitdb_types.clj
+++ b/src/xitdb/xitdb_types.clj
@@ -3,11 +3,11 @@
     [xitdb.array-list :as xarray-list]
     [xitdb.common :as common]
     [xitdb.hash-map :as xhash-map]
-    [xitdb.linked-list :as xlinked-list]
     [xitdb.hash-set :as xhash-set]
+    [xitdb.linked-list :as xlinked-list]
     [xitdb.util.conversion :as conversion])
   (:import
-    (io.github.radarroark.xitdb ReadCountedHashMap ReadCursor ReadHashMap Slot Tag WriteCursor WriteHashMap)))
+    [io.github.radarroark.xitdb ReadCursor Slot Tag WriteCursor]))
 
 (defn read-from-cursor
   "Reads the value at cursor and converts it to a Clojure type.

--- a/test/xitdb/cursor_test.clj
+++ b/test/xitdb/cursor_test.clj
@@ -1,0 +1,27 @@
+(ns xitdb.cursor-test
+  (:require
+    [clojure.test :refer :all]
+    [xitdb.db :as xdb]))
+
+(deftest CursorTest
+  (with-open [db (xdb/xit-db :memory)]
+    (reset! db {:foo {:bar [1 2 3 {:hidden true} 5]}})
+    (let [cursor1 (xdb/xdb-cursor db [:foo :bar])
+          cursor2 (xdb/xdb-cursor db [:foo :bar 2])
+          cursor3 (xdb/xdb-cursor db [:foo :bar 3 :hidden])]
+      (testing "Cursors return the value at keypath"
+        (is (= [1 2 3 {:hidden true} 5] (xdb/materialize @cursor1)))
+        (is (= 3 @cursor2))
+        (is (= true @cursor3)))
+
+      (testing "reset! on the cursor changes the underlying database"
+        (reset! cursor3 :changed)
+        (is (= :changed @cursor3))
+        (is (= :changed (get-in @db [:foo :bar 3 :hidden])))
+        (is (= [1 2 3 {:hidden :changed} 5]) (xdb/materialize @cursor1)))
+
+      (testing "swap! mutates the value at cursor"
+        (swap! cursor1 assoc-in [3 :hidden] :changed-by-swap!)
+        (is (= [1 2 3 {:hidden :changed-by-swap!} 5]) (xdb/materialize @cursor1))
+        (is (= :changed-by-swap! @cursor3))
+        (is (= 3 @cursor2))))))


### PR DESCRIPTION
A cursor takes an 'XITDB db' and a `keypath`.

A cursor will return the value of db at `keypath` and any mutation on the cursor will be placed at `keypath` in the original db.
You can create a cursor from a XITDBDatabase or a XITDBCursor. 
