### PR TITLE
Add on-disk sorted maps and sets backed by rank-augmented B-tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,64 @@ Here's a taste of how your queries could look like:
 
 ```
 
+## Sorted collections
+
+In addition to (unordered) hash maps and sets, xitdb supports **on-disk sorted
+maps and sets**, backed by the engine's rank-augmented B-tree. Store a Clojure
+`sorted-map` / `sorted-set` and it is persisted as a sorted collection that keeps
+its keys/members ordered on disk:
+
+```clojure
+(reset! db (sorted-map "banana" 2 "apple" 1 "cherry" 3))
+
+@db
+;; => #XITDBSortedMap{"apple" 1, "banana" 2, "cherry" 3}
+
+(swap! db assoc "date" 4) ;; inserted in order, not appended
+```
+
+Reading back yields an `XITDBSortedMap` / `XITDBSortedSet` that implements
+Clojure's ordered interfaces, so `seq`, `rseq`, `nth`, `subseq` and `rsubseq`
+all work and read only what they touch from disk:
+
+```clojure
+(reset! db (into (sorted-map) (map vector (range 0 100 2) (range))))
+
+(nth @db 10)          ;; => [20 10]   ;; O(log n), no full scan
+(subseq @db >= 90)    ;; => ([90 45] [92 46] [94 47] [96 48] [98 49])
+(rseq @db)            ;; => lazy descending seq of entries
+```
+
+Supported key/member types are strings, keywords, longs, doubles, `Instant`
+and `Date`. They are stored with an order-preserving codec, so they iterate in
+natural order — numeric for numbers, chronological for temporals, lexicographic
+(by code point) for strings. Longs and doubles share a single numeric ordering,
+so they interleave by value (e.g. `1 < 1.5 < 2`). Only the default ordering is
+supported: `sorted-map-by` / `sorted-set-by` with a custom comparator is
+rejected.
+
+### Ranking & pagination
+
+The `xitdb.sorted` namespace exposes the B-tree's O(log n) superpowers, which
+are handy for building and paging on-disk secondary indexes:
+
+- `(rank coll k)` — number of entries strictly less than `k` (i.e. the index of
+  `k`, or its would-be insertion index if absent).
+- `(from-index coll n)` — lazy ordered seq starting at rank `n`.
+- `(page coll offset limit)` — lazy ordered page `[offset, offset+limit)`.
+
+```clojure
+(require '[xitdb.sorted :as xsorted])
+
+;; build a timestamp -> id index; events can arrive out of order
+(reset! db (sorted-map))
+(doseq [e events]
+  (swap! db assoc (:ts e) (:id e)))
+
+(xsorted/rank @db some-ts)     ;; chronological position of some-ts
+(xsorted/page @db 100 20)      ;; the 20 entries at ranks [100, 120)
+```
+
 ## History
 
 Since the database is immutable, all previous values are accessed by reading
@@ -199,8 +257,10 @@ The Clojure wrapper adds:
 ### Supported Data Types
 
 - **Maps** - Hash maps with efficient key-value access
+- **Sorted maps** - On-disk B-tree maps with ordered iteration, `subseq`/`nth`/`rank`
 - **Vectors** - Array lists with indexed access
 - **Sets** - Hash sets with unique element storage
+- **Sorted sets** - On-disk B-tree sets with ordered iteration and ranking
 - **Lists** - Linked lists and RRB tree-based linked array lists
 - **Primitives** - Numbers, strings, keywords, booleans, dates.
 

--- a/src/xitdb/sorted_map.clj
+++ b/src/xitdb/sorted_map.clj
@@ -5,11 +5,11 @@
   used inside a transaction. Ordering is by the engine's unsigned byte
   comparison over order-preserving encoded keys (see `xitdb.util.sorted-key`).
 
-  The `clojure.lang.Sorted`/`Indexed`/`Reversible` protocols (subseq, nth, rseq)
-  are added in a later slice; this slice provides ascending ordered `seq` only."
+  Both views implement `clojure.lang.Sorted`/`Indexed`/`Reversible` (subseq,
+  nth, rseq) on top of the rank-augmented B-tree, in addition to ascending
+  ordered `seq`."
   (:require
     [xitdb.common :as common]
-    [xitdb.util.conversion :as conversion]
     [xitdb.util.sorted-key :as sorted-key]
     [xitdb.util.sorted-operations :as sorted-ops])
   (:import
@@ -216,6 +216,41 @@
   clojure.lang.Seqable
   (seq [_]
     (smap-seq wsm))
+
+  ;; The same ordered read machinery as XITDBSortedMap, reading the
+  ;; in-transaction (uncommitted) state. `WriteSortedMap` is a `ReadSortedMap`
+  ;; subclass, so the rank/index-based ops apply directly to `wsm`.
+  clojure.lang.Sorted
+  (comparator [_]
+    sorted-key/key-comparator)
+
+  (entryKey [_ entry]
+    (key entry))
+
+  (seq [_ ascending?]
+    (if ascending?
+      (smap-seq wsm)
+      (sorted-ops/smap-rseq wsm common/-read-from-cursor)))
+
+  (seqFrom [_ key ascending?]
+    (if ascending?
+      (sorted-ops/smap-seq-from wsm common/-read-from-cursor key)
+      (sorted-ops/smap-rseq wsm common/-read-from-cursor
+                            (descending-start-index wsm key))))
+
+  clojure.lang.Indexed
+  (nth [this i]
+    (let [e (.nth this i ::not-found)]
+      (if (identical? e ::not-found)
+        (throw (IndexOutOfBoundsException.))
+        e)))
+
+  (nth [_ i not-found]
+    (sorted-ops/smap-nth wsm common/-read-from-cursor i not-found))
+
+  clojure.lang.Reversible
+  (rseq [_]
+    (sorted-ops/smap-rseq wsm common/-read-from-cursor))
 
   clojure.core.protocols/IKVReduce
   (kv-reduce [this f init]

--- a/src/xitdb/sorted_set.clj
+++ b/src/xitdb/sorted_set.clj
@@ -174,6 +174,40 @@
   (seq [_]
     (sorted-ops/sset-seq wss))
 
+  ;; The same ordered read machinery as XITDBSortedSet, reading the
+  ;; in-transaction (uncommitted) state. `WriteSortedSet` is a `ReadSortedSet`
+  ;; subclass, so the rank/index-based ops apply directly to `wss`.
+  clojure.lang.Sorted
+  (comparator [_]
+    sorted-key/key-comparator)
+
+  (entryKey [_ entry]
+    entry)
+
+  (seq [_ ascending?]
+    (if ascending?
+      (sorted-ops/sset-seq wss)
+      (sorted-ops/sset-rseq wss)))
+
+  (seqFrom [_ member ascending?]
+    (if ascending?
+      (sorted-ops/sset-seq-from wss member)
+      (sorted-ops/sset-rseq wss (descending-start-index wss member))))
+
+  clojure.lang.Indexed
+  (nth [this i]
+    (let [e (.nth this i ::not-found)]
+      (if (identical? e ::not-found)
+        (throw (IndexOutOfBoundsException.))
+        e)))
+
+  (nth [_ i not-found]
+    (sorted-ops/sset-nth wss i not-found))
+
+  clojure.lang.Reversible
+  (rseq [_]
+    (sorted-ops/sset-rseq wss))
+
   clojure.lang.ILookup
   (valAt [this k]
     (.valAt this k nil))

--- a/src/xitdb/util/sorted_key.clj
+++ b/src/xitdb/util/sorted_key.clj
@@ -236,8 +236,8 @@
       (keyword nil (String. ba 2 (- (alength ba) 2) StandardCharsets/UTF_8))
       (let [sep (loop [i 2]
                   (if (zero? (aget ba i)) i (recur (inc i))))
-            ns  (String. ba 2 (- sep 2) StandardCharsets/UTF_8)
-            nm  (String. ba (inc sep) (- (alength ba) (inc sep)) StandardCharsets/UTF_8)]
+            ns  (String. ba (int 2) (int (- sep 2)) StandardCharsets/UTF_8)
+            nm  (String. ba (int (inc sep)) (int (- (alength ba) (inc sep))) StandardCharsets/UTF_8)]
         (keyword ns nm)))))
 
 (def key-comparator

--- a/src/xitdb/util/sorted_key.clj
+++ b/src/xitdb/util/sorted_key.clj
@@ -29,14 +29,21 @@
 ;; Type tags. Ordering of the tag values defines the cross-type order; they are
 ;; intentionally sparse to leave room for additional types in later slices.
 ;; Current cross-type order (by ascending tag byte):
-;;   long (0x10) < double (0x11) < instant (0x18) < date (0x19)
-;;   < string (0x20) < keyword (0x21)
-(def ^:const tag-long    (int 0x10))
-(def ^:const tag-double  (int 0x11))
+;;   number (0x10) < instant (0x18) < date (0x19) < string (0x20) < keyword (0x21)
+;; Longs and doubles share the single `tag-number` so they interleave by numeric
+;; value (see `number-body`) instead of being split into two adjacent ranges.
+(def ^:const tag-number  (int 0x10))
 (def ^:const tag-instant (int 0x18))
 (def ^:const tag-date    (int 0x19))
 (def ^:const tag-string  (int 0x20))
 (def ^:const tag-keyword (int 0x21))
+
+;; Numeric subtype byte (the body byte right after the 8-byte sort key).
+;; `num-long` sorts before `num-double`, so a long and a double of equal numeric
+;; value order deterministically (long first); it is only ever consulted as a
+;; tie-breaker between values that share a sort key.
+(def ^:const num-long   (int 0x00))
+(def ^:const num-double (int 0x01))
 
 (defn- ^bytes utf8 [^String s]
   (.getBytes s StandardCharsets/UTF_8))
@@ -80,6 +87,37 @@
                (bit-and flipped Long/MAX_VALUE)
                (bit-not flipped))]
     (Double/longBitsToDouble bits)))
+
+(defn- ^bytes number-body
+  "Order-preserving, reversible body shared by long and double keys, so the two
+  types interleave by numeric value in one space.
+
+  Layout (17 bytes, after the type tag):
+    [8-byte sort key][1-byte subtype][8-byte exact value]
+
+  The sort key is the value rendered through `double->bytes`, so unsigned byte
+  comparison of two sort keys matches numeric comparison to double precision
+  (~53 significant bits). The `subtype` byte (long < double) and the exact 8
+  bytes break ties between values that share a sort key, keeping the order total
+  and making the original long/double recoverable on decode.
+
+  Caveat: because the sort key has double precision, two values that differ only
+  beyond 2^53 *and* have different types (one long, one double) can order by the
+  tie-break rather than strictly by value. Same-type ordering is always exact."
+  [subtype ^bytes sortkey ^bytes exact]
+  (let [out (ByteArrayOutputStream. 17)]
+    (.write out sortkey 0 8)
+    (.write out (int subtype))
+    (.write out exact 0 8)
+    (.toByteArray out)))
+
+(defn- decode-number
+  "Inverse of `number-body`. The subtype byte is at offset 9 (1 type tag + 8
+  sort-key bytes) and the exact value occupies the 8 bytes at offset 10."
+  [^bytes ba]
+  (if (= (bit-and (int (aget ba 9)) 0xff) num-long)
+    (bytes->long ba 10)
+    (bytes->double ba 10)))
 
 (defn- ^bytes instant->bytes
   "12 bytes: epoch-second (8-byte big-endian, sign-flipped so negative epochs
@@ -155,14 +193,24 @@
     (tagged tag-keyword (keyword->bytes k))
 
     (integer? k)
-    (tagged tag-long (long->bytes (long k)))
+    (let [n (try
+              (long k)
+              (catch IllegalArgumentException _
+                (throw (IllegalArgumentException.
+                         (str "Integer sorted-map key out of range: " k
+                              ". Sorted collections encode integer keys as signed "
+                              "64-bit longs, so keys must be within "
+                              "[" Long/MIN_VALUE ", " Long/MAX_VALUE "].")))))]
+      (tagged tag-number
+              (number-body num-long (double->bytes (double n)) (long->bytes n))))
 
     (float? k)
     (let [d (double k)]
       (when (Double/isNaN d)
         (throw (IllegalArgumentException.
                  "NaN is not a valid sorted-map key (ordering undefined)")))
-      (tagged tag-double (double->bytes d)))
+      (tagged tag-number
+              (number-body num-double (double->bytes d) (double->bytes d))))
 
     (instance? Instant k)
     (tagged tag-instant (instant->bytes k))
@@ -208,8 +256,7 @@
     (condp = tag
       tag-string  (utf8-body ba)
       tag-keyword (decode-keyword ba)
-      tag-long    (bytes->long ba 1)
-      tag-double  (bytes->double ba 1)
+      tag-number  (decode-number ba)
       tag-instant (bytes->instant ba 1)
       tag-date    (bytes->date ba 1)
       (throw (IllegalArgumentException. (str "Unknown sorted-key tag: " tag))))))

--- a/src/xitdb/util/sorted_operations.clj
+++ b/src/xitdb/util/sorted_operations.clj
@@ -38,12 +38,13 @@
   wsm)
 
 (defn smap-empty!
-  "Replaces contents with an empty sorted map, in place."
+  "Replaces contents with an empty sorted map, in place. Returns the
+  WriteSortedMap. Mirrors `operations/map-empty!`: writes a fresh empty
+  SORTED_MAP slot at the cursor so the value stays a sorted map (the
+  `key-comparator` makes `v->slot!` accept it as a default-ordered tree)."
   [^WriteSortedMap wsm]
   (let [^WriteCursor cursor (.-cursor wsm)]
-    (.write cursor nil)
-    ;; re-init an empty sorted map at the same cursor the wsm holds
-    (WriteSortedMap. cursor))
+    (.write cursor (conversion/v->slot! cursor (sorted-map-by sorted-key/key-comparator))))
   wsm)
 
 (defn smap-seq
@@ -155,11 +156,12 @@
   wss)
 
 (defn sset-empty!
-  "Replaces contents with an empty sorted set, in place."
+  "Replaces contents with an empty sorted set, in place. Returns the
+  WriteSortedSet. Mirrors `operations/set-empty!`: writes a fresh empty
+  SORTED_SET slot at the cursor so the value stays a sorted set."
   [^WriteSortedSet wss]
   (let [^WriteCursor cursor (.-cursor wss)]
-    (.write cursor nil)
-    (WriteSortedSet. cursor))
+    (.write cursor (conversion/v->slot! cursor (sorted-set-by sorted-key/key-comparator))))
   wss)
 
 (defn- member-from-cursor

--- a/src/xitdb/util/sorted_operations.clj
+++ b/src/xitdb/util/sorted_operations.clj
@@ -6,7 +6,7 @@
     [xitdb.util.conversion :as conversion]
     [xitdb.util.sorted-key :as sorted-key])
   (:import
-    [io.github.radarroark.xitdb ReadCursor WriteCursor ReadSortedMap WriteSortedMap ReadSortedSet WriteSortedSet]))
+    [io.github.radarroark.xitdb ReadCursor ReadCursor$KeyValuePairCursor WriteCursor ReadSortedMap WriteSortedMap ReadSortedSet WriteSortedSet]))
 
 (defn smap-item-count
   "O(1) entry count, delegating to the rank-augmented B-tree."
@@ -66,7 +66,7 @@
 (defn- kvpair->entry
   "Turns a Java KeyValuePair (with .-keyCursor/.-valueCursor) into a Clojure
   MapEntry (decoded key, read value)."
-  [kv read-from-cursor]
+  [^ReadCursor$KeyValuePairCursor kv read-from-cursor]
   (clojure.lang.MapEntry.
     (decode-key-cursor (.-keyCursor kv))
     (read-from-cursor (.-valueCursor kv))))
@@ -166,12 +166,12 @@
 
 (defn- member-from-cursor
   "Decodes the member from a set entry cursor (its key cursor)."
-  [cursor]
+  [^ReadCursor cursor]
   (decode-key-cursor (.-keyCursor (.readKeyValuePair cursor))))
 
 (defn- kvpair->member
   "Decodes the member from a Java KeyValuePair (its key cursor)."
-  [kv]
+  [^ReadCursor$KeyValuePairCursor kv]
   (decode-key-cursor (.-keyCursor kv)))
 
 (defn sset-seq

--- a/test/xitdb/sorted_key_test.clj
+++ b/test/xitdb/sorted_key_test.clj
@@ -101,6 +101,37 @@
   (= (Integer/signum (compare a b))
      (Integer/signum (cmp-unsigned (sk/encode-key a) (sk/encode-key b)))))
 
+(deftest cross-type-numeric-order
+  (testing "longs and doubles interleave by numeric value, not by type tag"
+    (doseq [[a b] [[1 1.5] [1.5 2] [1 2.0] [2.0 3]
+                   [-1 -0.5] [-1.5 -1] [-1.0 0] [0 0.5]
+                   ;; magnitudes that exercise the gap between the two old tags
+                   [3 3.5] [-3.5 -3]
+                   ;; a long below and a double above zero and vice-versa
+                   [-2 1.0] [-1.5 2]]]
+      (is (neg? (cmp-unsigned (sk/encode-key a) (sk/encode-key b)))
+          (str a " < " b))
+      (is (pos? (cmp-unsigned (sk/encode-key b) (sk/encode-key a)))
+          (str b " > " a)))))
+
+(deftest prop-cross-type-numeric-order
+  (testing "for 4000 random long/double pairs of distinct value, byte order
+            agrees in sign with clojure.core/compare (the numeric order)"
+    (let [r        (java.util.Random. 77)
+          rand-num (fn [] (if (.nextBoolean r)
+                            (long (.nextInt r 2000000))           ;; small long
+                            (* (.nextDouble r) 1.0e6
+                               (if (.nextBoolean r) 1.0 -1.0))))] ;; small double
+      (is (every?
+            (fn [_]
+              (let [a (rand-num) b (rand-num)
+                    c (compare a b)]
+                (or (zero? c) ;; numerically equal (e.g. 1 vs 1.0): order is unspecified
+                    (= (Integer/signum c)
+                       (Integer/signum (cmp-unsigned (sk/encode-key a)
+                                                     (sk/encode-key b)))))))
+            (range 4000))))))
+
 (deftest prop-long-order
   (testing "for 2000 random long pairs, byte order == numeric order"
     (let [r (java.util.Random. 42)]
@@ -153,6 +184,18 @@
   (is (thrown? IllegalArgumentException (sk/encode-key nil)))
   (is (thrown? IllegalArgumentException (sk/encode-key true)))
   (is (thrown? IllegalArgumentException (sk/encode-key Double/NaN))))
+
+(deftest out-of-range-integer-key-throws-clearly
+  (testing "an integer key past the 64-bit long range is rejected eagerly with a
+            clear, key-specific message rather than a raw numeric-cast error"
+    (doseq [big [(.pow (java.math.BigInteger. "2") 100)
+                 (.negate (.pow (java.math.BigInteger. "2") 100))
+                 (bigint "99999999999999999999999")]]
+      (let [ex (is (thrown? IllegalArgumentException (sk/encode-key big)))]
+        (is (re-find #"(?i)key" (.getMessage ex))
+            "message should mention it is about a key")
+        (is (re-find #"(?i)long" (.getMessage ex))
+            "message should mention the long range")))))
 
 (deftest instant-roundtrip
   (testing "instants round-trip to Instant, preserving sub-second precision"

--- a/test/xitdb/sorted_map_test.clj
+++ b/test/xitdb/sorted_map_test.clj
@@ -164,6 +164,20 @@
     (swap! db assoc "c" 3)
     (is (= ["c"] (map key (seq @db))))))
 
+(deftest empty-then-reassoc-stays-a-sorted-map
+  (testing "after (swap! db empty) the value is still a sorted map, so keys
+            re-inserted afterwards keep sorted (not hash-map) semantics"
+    (with-open [db (xdb/xit-db :memory)]
+      (reset! db (sorted-map "a" 1 "b" 2))
+      (swap! db empty)
+      (is (instance? xitdb.sorted_map.XITDBSortedMap @db))
+      (is (sorted? @db))
+      (is (= 0 (count @db)))
+      (swap! db assoc "c" 3 "a" 1)
+      (is (instance? xitdb.sorted_map.XITDBSortedMap @db))
+      (is (sorted? @db))
+      (is (= ["a" "c"] (map key (seq @db)))))))
+
 (deftest print-method-ordered
   (with-open [db (xdb/xit-db :memory)]
     (reset! db (sorted-map "b" 2 "a" 1))
@@ -266,6 +280,28 @@
       (reset! db (sorted-map 3.5 :a -1.5 :b 0.0 :c 1.0e308 :d -1.0e308 :e))
       (is (= [-1.0e308 -1.5 0.0 3.5 1.0e308] (map key (seq @db)))))))
 
+(deftest mixed-long-double-keys-interleave-numerically
+  (testing "long and double keys sort by numeric value and round-trip with type"
+    (with-open [db (xdb/xit-db :memory)]
+      (reset! db (into (sorted-map)
+                       (map vector [1 0.5 2 1.5 3 -1.5] (range))))
+      (is (= [-1.5 0.5 1 1.5 2 3] (map key (seq @db))))
+      (is (some #(instance? Double %) (map key (seq @db))))
+      (is (some integer? (map key (seq @db))))))
+  (testing "matches the in-memory Clojure sorted-map oracle for mixed keys"
+    (with-open [db (xdb/xit-db :memory)]
+      (let [oracle (into (sorted-map)
+                         (map vector [10 2.5 7 0.25 -3 -3.5 100.0 4] (range)))]
+        (reset! db oracle)
+        (is (= (keys oracle) (map key (seq @db)))))))
+  (testing "a double bound queries a long-keyed map at the right place (subseq)"
+    (with-open [db (xdb/xit-db :memory)]
+      (reset! db (into (sorted-map) (map vector [1 2 3 4 5] (range))))
+      (let [m @db]
+        (is (= [2 3 4 5] (map key (subseq m >= 1.5))))
+        (is (= [1 2 3]   (map key (subseq m <= 3.5))))
+        (is (= [3 4]     (map key (subseq m > 2.5 < 4.5))))))))
+
 (deftest temporal-keys-iterate-chronologically
   (testing "Instant keys iterate chronologically and round-trip to Instant"
     (with-open [db (xdb/xit-db :memory)]
@@ -281,6 +317,25 @@
         (reset! db (sorted-map d2 :c d0 :a d1 :b))
         (is (= [d0 d1 d2] (map key (seq @db))))
         (is (every? #(instance? Date %) (map key (seq @db))))))))
+
+(deftest write-view-supports-sorted-indexed-reversible
+  (testing "the writeable sorted map handed to swap! supports nth/subseq/rseq
+            and exposes the same comparator as the read view"
+    (with-open [db (xdb/xit-db :memory)]
+      (reset! db (into (sorted-map) (map vector (range 5) (range 5))))
+      (swap! db
+             (fn [m]
+               (is (= (clojure.lang.MapEntry. 0 0) (nth m 0)))
+               (is (= 2 (key (nth m 2))))
+               (is (= ::nf (nth m 99 ::nf)))
+               (is (= [2 3 4] (map key (subseq m >= 2))))
+               (is (= [0 1] (map key (subseq m < 2))))
+               (is (= [4 3 2 1 0] (map key (rseq m))))
+               (is (instance? java.util.Comparator
+                              (.comparator ^clojure.lang.Sorted m)))
+               m))
+      (testing "the data is unchanged after read-only queries in the txn"
+        (is (= [0 1 2 3 4] (map key (seq @db))))))))
 
 (deftest tracer-bullet-ordered-seq
   (testing "a persisted sorted-map is stored as a sorted map and seqs in key order"

--- a/test/xitdb/sorted_set_test.clj
+++ b/test/xitdb/sorted_set_test.clj
@@ -215,6 +215,25 @@
       (is (clojure.string/starts-with? s "#XITDBSortedSet"))
       (is (clojure.string/includes? s "1 2 3")))))
 
+(deftest write-view-supports-sorted-indexed-reversible
+  (testing "the writeable sorted set handed to swap! supports nth/subseq/rseq
+            and exposes the same comparator as the read view"
+    (with-open [db (xdb/xit-db :memory)]
+      (reset! db (into (sorted-set) (range 5)))
+      (swap! db
+             (fn [s]
+               (is (= 0 (nth s 0)))
+               (is (= 2 (nth s 2)))
+               (is (= ::nf (nth s 99 ::nf)))
+               (is (= [2 3 4] (subseq s >= 2)))
+               (is (= [0 1] (subseq s < 2)))
+               (is (= [4 3 2 1 0] (rseq s)))
+               (is (instance? java.util.Comparator
+                              (.comparator ^clojure.lang.Sorted s)))
+               s))
+      (testing "the data is unchanged after read-only queries in the txn"
+        (is (= [0 1 2 3 4] (seq @db)))))))
+
 (deftest nesting-and-round-trip
   (testing "sorted set nests inside a hash map value"
     (with-open [db (xdb/xit-db :memory)]
@@ -239,4 +258,15 @@
       (is (= 0 (count @db)))
       (is (empty? (seq @db)))
       (swap! db conj 7)
-      (is (= [7] (seq @db))))))
+      (is (= [7] (seq @db)))))
+  (testing "after empty the value is still a sorted set, so re-inserted members
+            keep sorted (not hash-set) semantics"
+    (with-open [db (xdb/xit-db :memory)]
+      (reset! db (sorted-set 1 2 3))
+      (swap! db empty)
+      (is (instance? xitdb.sorted_set.XITDBSortedSet @db))
+      (is (sorted? @db))
+      (swap! db conj 5 1 3)
+      (is (instance? xitdb.sorted_set.XITDBSortedSet @db))
+      (is (sorted? @db))
+      (is (= [1 3 5] (seq @db))))))


### PR DESCRIPTION
## Summary

This PR adds support for on-disk sorted collections to xitdb. Users can now persist Clojure `sorted-map` and `sorted-set` instances, which are stored as sorted collections that maintain key/member ordering on disk using the engine's rank-augmented B-tree.

## Key Changes

- **New sorted collection types**: `XITDBSortedMap` and `XITDBSortedSet` wrapper types that implement `clojure.lang.Sorted`, `clojure.lang.Indexed`, and `clojure.lang.Reversible` interfaces
  - Read views (`XITDBSortedMap`, `XITDBSortedSet`) for querying persisted collections
  - Write views (`XITDBWriteSortedMap`, `XITDBWriteSortedSet`) for mutations within transactions

- **Order-preserving key codec** (`xitdb.util.sorted-key`):
  - Encodes keys as order-preserving, reversible bytes so real keys are recoverable on read
  - Supports heterogeneous key types: strings, keywords (including namespaced), longs, doubles, `Instant`, and `Date`
  - Type tags establish cross-type ordering so heterogeneous collections never throw
  - Keyword ordering matches Clojure's default comparator (non-namespaced before namespaced)

- **Sorted operations bridge** (`xitdb.util.sorted-operations`):
  - Bridges wrapper types to Java `ReadSortedMap`/`WriteSortedMap` and `ReadSortedSet`/`WriteSortedSet`
  - Implements rank-based pagination: `rank` (O(log n) index lookup), `page`, and `from-index` helpers
  - Supports `subseq`, `rseq`, and indexed access (`nth`) on top of the B-tree

- **Public API** (`xitdb.sorted`):
  - `rank` - O(log n) index of a key/member (inverse of indexed `nth`)
  - `page` - lazy ordered page starting at a rank (offset/limit)
  - `from-index` - lazy ordered seq starting at a rank

- **Comprehensive test coverage**:
  - `sorted_map_test.clj`: lookups, mutations, ordering, keyword handling, heterogeneous keys, materialization
  - `sorted_set_test.clj`: membership, mutations, ordering, materialization
  - `sorted_key_test.clj`: roundtrip encoding/decoding, order preservation across types
  - `sorted_pagination_test.clj`: rank queries and pagination on both maps and sets

- **Integration with existing infrastructure**:
  - Updated `xitdb.util.conversion` to handle `SORTED_MAP` and `SORTED_SET` tags
  - Updated `xitdb.xitdb-types` to register sorted collection types
  - Updated `README.md` with sorted collections documentation and examples

## Notable Implementation Details

- Keys are stored as real bytes (not hashed like hash maps), enabling recovery and comparison by the engine's unsigned lexicographic byte comparison
- The codec is reversible: `decode-key(encode-key(k)) == k` for all supported types
- Heterogeneous collections are supported through type tags that establish a total order across types
- Materialized sorted maps/sets carry their key-comparator and can be written back to the database without rejection
- All `Sorted` interface methods (`seq`, `seqFrom`, `rseq`) are implemented with lazy evaluation

https://claude.ai/code/session_01XprXbzsgFtSJnXpR9G12dH