### PR TITLE
cleanup: remove unnecessary IReadOnly protocol

### DIFF
--- a/src/xitdb/array_list.clj
+++ b/src/xitdb/array_list.clj
@@ -248,17 +248,13 @@
   (-unwrap [this]
     wal)
 
-  common/IReadOnly
-  (-read-only [this]
-    (XITDBArrayList. wal))
-
   Object
   (toString [this]
     (str "XITDBWriteArrayList")))
 
 (defmethod print-method XITDBWriteArrayList [o ^java.io.Writer w]
   (.write w "#XITDBWriteArrayList")
-  (print-method (into [] (common/-read-only o)) w))
+  (print-method (into [] (seq o)) w))
 
 ;; Constructors
 

--- a/src/xitdb/common.clj
+++ b/src/xitdb/common.clj
@@ -15,9 +15,6 @@
 (defprotocol IUnwrap
   (-unwrap [this]))
 
-(defprotocol IReadOnly
-  (-read-only [this]))
-
 (defn materialize [v]
   (cond
     (satisfies? IMaterialize v) (-materialize v)

--- a/src/xitdb/db.clj
+++ b/src/xitdb/db.clj
@@ -310,12 +310,14 @@
   outside of a transaction. Returns a read-only version of the
   given writeable data structure."
   [x]
-  (when-not (satisfies? common/IReadOnly x)
-    (throw (IllegalArgumentException.
-             (str "freeze! requires a writeable XITDB data structure, got: " (type x)))))
-  (let [^ReadCursor cursor (-> x common/-unwrap .cursor)
-        ^Database writer (.-db cursor)
-        ^Database reader (db-context/reader-database writer)]
-    (.freeze writer)
-    (.flush ^Core (.-core writer))
-    (xtypes/read-from-cursor (ReadCursor. (.-slotPtr cursor) reader) false)))
+  (let [^ReadCursor cursor (when (common/wrapper? x)
+                             (-> x common/-unwrap .cursor))]
+    (when-not (instance? WriteCursor cursor)
+      (throw (IllegalArgumentException.
+               (str "freeze! requires a writeable XITDB data structure, got: " (type x)))))
+    (let [^Database writer (.-db cursor)
+          ^Database reader (db-context/reader-database writer)]
+      (.freeze writer)
+      (.flush ^Core (.-core writer))
+      ;; rebuild on the reader handle so the value can be shared across threads
+      (xtypes/read-from-cursor (ReadCursor. (.-slotPtr cursor) reader) false))))

--- a/src/xitdb/hash_map.clj
+++ b/src/xitdb/hash_map.clj
@@ -184,17 +184,13 @@
   (-unwrap [this]
     whm)
 
-  common/IReadOnly
-  (-read-only [this]
-    (XITDBHashMap. whm))
-
   Object
   (toString [this]
     (str "XITDBWriteHashMap")))
 
 (defmethod print-method XITDBWriteHashMap [o ^java.io.Writer w]
   (.write w "#XITDBWriteHashMap")
-  (print-method (into {} (common/-read-only o)) w))
+  (print-method (into {} (seq o)) w))
 
 (defn xwrite-hash-map [^WriteCursor write-cursor]
   (->XITDBWriteHashMap (WriteHashMap. write-cursor)))

--- a/src/xitdb/hash_set.clj
+++ b/src/xitdb/hash_set.clj
@@ -144,17 +144,13 @@
   (-unwrap [_]
     whs)
 
-  common/IReadOnly
-  (-read-only [this]
-    (XITDBHashSet. whs))
-
   Object
   (toString [_]
     (str "XITDBWriteHashSet")))
 
 (defmethod print-method XITDBWriteHashSet [o ^java.io.Writer w]
   (.write w "#XITDBWriteHashSet")
-  (print-method (into #{} (common/-read-only o)) w))
+  (print-method (into #{} (seq o)) w))
 
 ;; Constructor functions
 (defn xwrite-hash-set [^WriteCursor write-cursor]

--- a/src/xitdb/linked_list.clj
+++ b/src/xitdb/linked_list.clj
@@ -230,17 +230,13 @@
   (-unwrap [this]
     wlal)
 
-  common/IReadOnly
-  (-read-only [this]
-    (XITDBLinkedArrayList. wlal))
-
   Object
   (toString [this]
     (str "XITDBWriteLinkedArrayList")))
 
 (defmethod print-method XITDBWriteLinkedArrayList [o ^java.io.Writer w]
   (.write w "#XITDBWriteLinkedArrayList")
-  (print-method (into [] (common/-read-only o)) w))
+  (print-method (into [] (seq o)) w))
 
 ;; Constructors
 

--- a/src/xitdb/sorted_map.clj
+++ b/src/xitdb/sorted_map.clj
@@ -267,17 +267,13 @@
   (-unwrap [this]
     wsm)
 
-  common/IReadOnly
-  (-read-only [this]
-    (XITDBSortedMap. wsm))
-
   Object
   (toString [this]
     (str "XITDBWriteSortedMap")))
 
 (defmethod print-method XITDBWriteSortedMap [o ^java.io.Writer w]
   (.write w "#XITDBWriteSortedMap")
-  (print-method (into (sorted-map-by sorted-key/key-comparator) (common/-read-only o)) w))
+  (print-method (into (sorted-map-by sorted-key/key-comparator) (seq o)) w))
 
 (defn xwrite-sorted-map [^WriteCursor write-cursor]
   (->XITDBWriteSortedMap (WriteSortedMap. write-cursor)))

--- a/src/xitdb/sorted_set.clj
+++ b/src/xitdb/sorted_set.clj
@@ -225,17 +225,13 @@
   (-unwrap [_]
     wss)
 
-  common/IReadOnly
-  (-read-only [this]
-    (XITDBSortedSet. wss))
-
   Object
   (toString [_]
     (str "XITDBWriteSortedSet")))
 
 (defmethod print-method XITDBWriteSortedSet [o ^java.io.Writer w]
   (.write w "#XITDBWriteSortedSet")
-  (print-method (into (sorted-set-by sorted-key/key-comparator) (common/-read-only o)) w))
+  (print-method (into (sorted-set-by sorted-key/key-comparator) (seq o)) w))
 
 ;; Constructor functions
 (defn xwrite-sorted-set [^WriteCursor write-cursor]


### PR DESCRIPTION
I found that `IReadOnly` isn't actually necessary anymore so I removed it.