### PR TITLE
update xitdb to improve truncation behavior

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "test"]
  :deps  {org.clojure/clojure        {:mvn/version "1.12.0"}
-         io.github.radarroark/xitdb {:mvn/version "0.36.0"}}
+         io.github.radarroark/xitdb {:mvn/version "0.37.0"}}
 
  :aliases
  {:test  {:extra-deps {io.github.cognitect-labs/test-runner


### PR DESCRIPTION
While xitdb already truncates the database when an error happens during a transaction, in 0.37.0 it now cleans up leftover data if there is an unclean shutdown / crash during a transaction. This release also fixes a few related truncation bugs.